### PR TITLE
Add min-duration arg to audio processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ rely on `ffmpeg` being installed and available on your `PATH`.
     
 8 - Run the `process_audio.py` script on the new folder. This will split the file
     into the chunks in the annotation file. Use the optional `--min-duration`
-    argument to control the minimum length (in seconds) of exported segments.
+    argument to control the minimum length (in seconds) of exported segments
+    (default is 0.75 seconds).
 
 
 ![Alt text](workflow.png)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ rely on `ffmpeg` being installed and available on your `PATH`.
     
 7 - Copy the audio and the annotation file you wish to process (eg: good only) and place it into a new folder.
     
-8 - Run the process_audio.py script on the new folder. Note: this will split the file into the chunks in the annotation file.
+8 - Run the `process_audio.py` script on the new folder. This will split the file
+    into the chunks in the annotation file. Use the optional `--min-duration`
+    argument to control the minimum length (in seconds) of exported segments.
 
 
 ![Alt text](workflow.png)

--- a/process_audio.py
+++ b/process_audio.py
@@ -4,9 +4,13 @@ import json
 import shutil
 import subprocess
 import re
+import argparse
 
-# Global minimum duration threshold in seconds
-MIN_DURATION = 0.75
+# Default minimum duration threshold in seconds
+DEFAULT_MIN_DURATION = 0.75
+
+# Runtime minimum duration threshold. This can be overridden via --min-duration
+MIN_DURATION = DEFAULT_MIN_DURATION
 
 def validate_json_data(data, json_filename):
     """
@@ -145,12 +149,22 @@ def main():
     - Expects a subfolder argument.
     - Validates that exactly one audio file exists in the folder.
     - Processes all JSON files in the folder sequentially.
+    - Allows overriding the minimum duration threshold.
     """
-    if len(sys.argv) != 2:
-        print("Usage: python process_audio.py <subfolder>")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(description="Process annotated audio files")
+    parser.add_argument("subfolder", help="Folder containing audio and JSON files")
+    parser.add_argument(
+        "--min-duration",
+        type=float,
+        default=DEFAULT_MIN_DURATION,
+        help="Minimum segment duration in seconds",
+    )
+    args = parser.parse_args()
 
-    subfolder = sys.argv[1]
+    global MIN_DURATION
+    MIN_DURATION = args.min_duration
+
+    subfolder = args.subfolder
     parent_dir = os.getcwd()
     process_dir = os.path.join(parent_dir, subfolder)
 


### PR DESCRIPTION
## Summary
- allow overriding minimum snippet duration with `--min-duration`
- document optional CLI flag in README

## Testing
- `python -m py_compile process_audio.py`

------
https://chatgpt.com/codex/tasks/task_e_684b33769b50833095341e3896caf2aa