### PR TITLE
Add GUI mode and refactor annotation processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ rely on `ffmpeg` being installed and available on your `PATH`.
 3 - Now you have the annotation file, and the audio file. Take the annotation and remove excess details (see example)
 
 4 - Run 'process_elevenlabs_annotations.py', selecting the speaker you want to extract and form full sentences from; saves to a new file.
+    - Run with arguments for CLI usage: `python process_elevenlabs_annotations.py input.json output.json`.
+    - If you run the script without arguments, a small GUI opens to pick the files and choose the speaker interactively.
 
 5 - You now have a file of sentences from one speaker; take this file and the video and place into one directory. Rename JSON to annotation.json
 


### PR DESCRIPTION
## Summary
- refactor `process_elevenlabs_annotations.py` into reusable functions
- add `run_gui()` Tkinter interface for selecting files and speaker
- preserve command line behavior when called with arguments
- document the new GUI workflow in the README

## Testing
- `python -m py_compile annotate.py process_audio.py process_elevenlabs_annotations.py`
- `python process_elevenlabs_annotations.py --help`
- `python process_elevenlabs_annotations.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_684b4124c6fc83308e0416841be2b6dd